### PR TITLE
Bug Fix: Saving and loading of Event objects is fixed

### DIFF
--- a/PocketPlanner Project/PocketPlanner Project/PocketPlanner/Monthly Events/EventTableViewController.swift
+++ b/PocketPlanner Project/PocketPlanner Project/PocketPlanner/Monthly Events/EventTableViewController.swift
@@ -19,7 +19,7 @@ class EventTableViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationItem.rightBarButtonItem = editButtonItem
-    
+        events = Event.loadEvents() ?? events
     }
     
     override func numberOfSections(in tableView: UITableView) -> Int {
@@ -57,6 +57,7 @@ class EventTableViewController: UITableViewController {
         if editingStyle == .delete {
             events.remove(at: indexPath.row)
             tableView.deleteRows(at: [indexPath], with: .fade)
+            Event.saveEvents(events)
             }
         }
     
@@ -85,6 +86,7 @@ class EventTableViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, moveRowAt fromIndexPath: IndexPath, to: IndexPath) {
         let movedEvents = events.remove(at: fromIndexPath.row)
         events.insert(movedEvents, at: to.row)
+        Event.saveEvents(events)
         tableView.reloadData()
     }
     
@@ -93,7 +95,9 @@ class EventTableViewController: UITableViewController {
 extension EventTableViewController: EventManagementDelegate {
     func addNew(_ event: Event) {
         let newIndexPath = IndexPath(row: events.count, section: 0)
+        events = Event.loadEvents() ?? events
         events.append(event)
+        Event.saveEvents(events)
         tableView.insertRows(at: [newIndexPath], with: .automatic)
     }
 }

--- a/PocketPlanner Project/PocketPlanner Project/PocketPlanner/Monthly Events/NewEvent.swift
+++ b/PocketPlanner Project/PocketPlanner Project/PocketPlanner/Monthly Events/NewEvent.swift
@@ -1,4 +1,3 @@
-/
 //  newEvent.swift
 //  MonthlyEvents:PocketPlanner
 //
@@ -39,4 +38,7 @@ struct Event: Codable {
 }
 
 let DocumentsDirectoryEvents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+                .appendingPathExtension("plist")
+    }()
+}
 

--- a/PocketPlanner Project/PocketPlanner Project/PocketPlanner/Monthly Planner/EventPopoverViewController.swift
+++ b/PocketPlanner Project/PocketPlanner Project/PocketPlanner/Monthly Planner/EventPopoverViewController.swift
@@ -97,7 +97,6 @@ class EventPopoverViewController: UIViewController {
         
         let event = Event(eventTitle: title, eventDate: dateText, startTime: startTime, endTime: endTime, eventDetails: eventNotes)
         eventManager.addNew(event)
-        Event.saveEvents(events)
         
     }
     


### PR DESCRIPTION
  - Saving Event objects was being done in an incorrect location
  - Loading event objects seemed to be failing, but it was because 0 events were being saved by the popover
  - Saving events must consider existing events, otherwise it will clobber saved events